### PR TITLE
updates for libpostal 1.0

### DIFF
--- a/src/postal.cpp
+++ b/src/postal.cpp
@@ -7,56 +7,100 @@ String poster_internal::isna(std::string x){
   return x;
 }
 
+enum {
+    PARSER_LABEL_HOUSE,
+    PARSER_LABEL_CATEGORY,
+    PARSER_LABEL_NEAR,
+    PARSER_LABEL_HOUSE_NUMBER,
+    PARSER_LABEL_ROAD,
+    PARSER_LABEL_UNIT,
+    PARSER_LABEL_LEVEL,
+    PARSER_LABEL_STAIRCASE,
+    PARSER_LABEL_ENTRANCE,
+    PARSER_LABEL_PO_BOX,
+    PARSER_LABEL_POSTCODE,
+    PARSER_LABEL_SUBURB,
+    PARSER_LABEL_CITY_DISTRICT,
+    PARSER_LABEL_CITY,
+    PARSER_LABEL_ISLAND,
+    PARSER_LABEL_STATE_DISTRICT,
+    PARSER_LABEL_STATE,
+    PARSER_LABEL_COUNTRY_REGION,
+    PARSER_LABEL_COUNTRY,
+    PARSER_LABEL_WORLD_REGION
+};
+
 CharacterVector poster_internal::parse_single(String x, address_parser_options_t& opts){
-  
   CharacterVector output(10, NA_STRING);
-  address_parser_response_t *parsed = parse_address((char*) x.get_cstring(), opts);
+  libpostal_address_parser_response_t *parsed = libpostal_parse_address((char*) x.get_cstring(), opts);
   std::string holding;
   for (unsigned int n = 0; n < parsed->num_components; n++) {
     holding = parsed->labels[n];
+
     // Optimise this by using an enum
-    if(holding == "house"){
-      output[0] = isna(parsed->components[n]);
+    if (holding == "house") {
+      output[PARSER_LABEL_HOUSE] = isna(parsed->components[n]);
     }
-    
-    if(holding == "house_number"){
-      output[1] = isna(parsed->components[n]);
+    if (holding == "category") {
+      output[PARSER_LABEL_CATEGORY] = isna(parsed->components[n]);
     }
-    
-    if(holding == "road"){
-      output[2] = isna(parsed->components[n]);
+    if (holding == "near") {
+      output[PARSER_LABEL_NEAR] = isna(parsed->components[n]);
     }
-    
-    if(holding == "suburb"){
-      output[3] = isna(parsed->components[n]);
+    if (holding == "house_number") {
+      output[PARSER_LABEL_HOUSE_NUMBER] = isna(parsed->components[n]);
     }
-    
-    if(holding == "city_district"){
-      output[4] = isna(parsed->components[n]);
+    if (holding == "road") {
+      output[PARSER_LABEL_ROAD] = isna(parsed->components[n]);
     }
-    
-    if(holding == "city"){
-      output[5] = isna(parsed->components[n]);
+    if (holding == "unit") {
+      output[PARSER_LABEL_UNIT] = isna(parsed->components[n]);
     }
-    
-    if(holding == "state_district"){
-      output[6] = isna(parsed->components[n]);
+    if (holding == "level") {
+      output[PARSER_LABEL_LEVEL] = isna(parsed->components[n]);
     }
-    
-    if(holding == "state"){
-      output[7] = isna(parsed->components[n]);
+    if (holding == "staircase") {
+      output[PARSER_LABEL_STAIRCASE] = isna(parsed->components[n]);
     }
-    
-    if(holding == "postcode"){
-      output[8] = isna(parsed->components[n]);
+    if (holding == "entrance") {
+      output[PARSER_LABEL_ENTRANCE] = isna(parsed->components[n]);
     }
-    
-    if(holding == "country"){
-      output[9] = isna(parsed->components[n]);
+    if (holding == "po_box") {
+      output[PARSER_LABEL_PO_BOX] = isna(parsed->components[n]);
+    }
+    if (holding == "postcode") {
+      output[PARSER_LABEL_POSTCODE] = isna(parsed->components[n]);
+    }
+    if (holding == "suburb") {
+      output[PARSER_LABEL_SUBURB] = isna(parsed->components[n]);
+    }
+    if (holding == "city_district") {
+      output[PARSER_LABEL_CITY_DISTRICT] = isna(parsed->components[n]);
+    }
+    if (holding == "city") {
+      output[PARSER_LABEL_CITY] = isna(parsed->components[n]);
+    }
+    if (holding == "island") {
+      output[PARSER_LABEL_ISLAND] = isna(parsed->components[n]);
+    }
+    if (holding == "state_district") {
+      output[PARSER_LABEL_STATE_DISTRICT] = isna(parsed->components[n]);
+    }
+    if (holding == "state") {
+      output[PARSER_LABEL_STATE] = isna(parsed->components[n]);
+    }
+    if (holding == "country_region") {
+      output[PARSER_LABEL_COUNTRY_REGION] = isna(parsed->components[n]);
+    }
+    if (holding == "country") {
+      output[PARSER_LABEL_COUNTRY] = isna(parsed->components[n]);
+    }
+    if (holding == "world_region") {
+      output[PARSER_LABEL_WORLD_REGION] = isna(parsed->components[n]);
     }
   }
 
-  address_parser_response_destroy(parsed);
+  libpostal_address_parser_response_destroy(parsed);
   return output;
 }
 
@@ -64,7 +108,7 @@ CharacterVector poster_internal::address_normalise(CharacterVector addresses){
   
   unsigned int input_size = addresses.size();
   CharacterVector output(input_size);
-  normalize_options_t options = get_libpostal_default_options();
+  normalize_options_t options = libpostal_get_default_options();
   size_t num_expansions;
   char **expansions;
   
@@ -80,14 +124,14 @@ CharacterVector poster_internal::address_normalise(CharacterVector addresses){
       
     } else {
       
-      expansions = expand_address(addresses[i], options, &num_expansions);
+      expansions = libpostal_expand_address(addresses[i], options, &num_expansions);
       if(num_expansions == 0){
         output[i] = addresses[i];
       } else {
         output[i] = std::string(expansions[0]);
       }
       
-      expansion_array_destroy(expansions, num_expansions);
+      libpostal_expansion_array_destroy(expansions, num_expansions);
       
     }
   }
@@ -99,83 +143,126 @@ DataFrame poster_internal::parse_addr(CharacterVector addresses){
   
   unsigned int input_size = addresses.size();
   CharacterVector house(input_size, NA_STRING);
+  CharacterVector category(input_size, NA_STRING);
+  CharacterVector near(input_size, NA_STRING);
   CharacterVector house_number(input_size, NA_STRING);
   CharacterVector road(input_size, NA_STRING);
+  CharacterVector unit(input_size, NA_STRING);
+  CharacterVector level(input_size, NA_STRING);
+  CharacterVector staircase(input_size, NA_STRING);
+  CharacterVector entrance(input_size, NA_STRING);
+  CharacterVector po_box(input_size, NA_STRING);
   CharacterVector suburb(input_size, NA_STRING);
   CharacterVector city_district(input_size, NA_STRING);
   CharacterVector city(input_size, NA_STRING);
+  CharacterVector island(input_size, NA_STRING);
   CharacterVector state_district(input_size, NA_STRING);
   CharacterVector state(input_size, NA_STRING);
   CharacterVector postal_code(input_size, NA_STRING);
   CharacterVector country(input_size, NA_STRING);
+  CharacterVector country_region(input_size, NA_STRING);
+  CharacterVector world_region(input_size, NA_STRING);
   CharacterVector holding;
-  address_parser_options_t options = get_libpostal_address_parser_default_options();
+
+  libpostal_address_parser_options_t options = libpostal_get_address_parser_default_options();
 
   for(unsigned int i = 0; i < input_size; i++){
     if((i % 10000) == 0){
       Rcpp::checkUserInterrupt();
     }
     if(addresses[i] != NA_STRING){
-      address_parser_response_t *parsed = parse_address((char*) addresses[i],
-                                                        options);
+      address_parser_response_t *parsed = libpostal_parse_address((char*) addresses[i],
+                                                                  options);
       std::string holding;
       for (unsigned int n = 0; n < parsed->num_components; n++) {
         holding = parsed->labels[n];
         // Optimise this by using an enum
-        if(holding == "house"){
+        if (holding == "house") {
           house[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "house_number"){
+        if (holding == "category") {
+          category[i] = isna(parsed->components[n]);
+        }
+        if (holding == "near") {
+          near[i] = isna(parsed->components[n]);
+        }
+        if (holding == "house_number") {
           house_number[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "road"){
+        if (holding == "road") {
           road[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "suburb"){
+        if (holding == "unit") {
+          unit[i] = isna(parsed->components[n]);
+        }
+        if (holding == "level") {
+          level[i] = isna(parsed->components[n]);
+        }
+        if (holding == "staircase") {
+          staircase[i] = isna(parsed->components[n]);
+        }
+        if (holding == "entrance") {
+          entrance[i] = isna(parsed->components[n]);
+        }
+        if (holding == "po_box") {
+          po_box[i] = isna(parsed->components[n]);
+        }
+        if (holding == "suburb") {
           suburb[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "city_district"){
+        if (holding == "city_district") {
           city_district[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "city"){
+        if (holding == "city") {
           city[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "state_district"){
+        if (holding == "island") {
+          island[i] = isna(parsed->components[n]);
+        }
+        if (holding == "state_district") {
           state_district[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "state"){
+        if (holding == "state") {
           state[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "postcode"){
+        if (holding == "postcode") {
           postal_code[i] = isna(parsed->components[n]);
         }
-        
-        if(holding == "country"){
+        if (holding == "country_region") {
+          country_region[i] = isna(parsed->components[n]);
+        }
+        if (holding == "country") {
           country[i] = isna(parsed->components[n]);
         }
+        if (holding == "world_region") {
+          world_region[i] = isna(parsed->components[n]);
+        }
+
       }
-      address_parser_response_destroy(parsed);
+      libpostal_address_parser_response_destroy(parsed);
     }
   }
-  
+
   return DataFrame::create(_["house"] = house,
+                           _["category"] = category,
+                           _["near"] = near,
                            _["house_number"] = house_number,
                            _["road"] = road,
+                           _["unit"] = unit,
+                           _["level"] = level,
+                           _["staircase"] = staircase,
+                           _["entrance"] = entrance,
+                           _["po_box"] = po_box,
                            _["suburb"] = suburb,
                            _["city_district"] = city_district,
                            _["city"] = city,
+                           _["island"] = island,
                            _["state_district"] = state_district,
                            _["state"] = state,
-                           _["postal_code"] = postal_code,
+                           _["postal_code"] = postcode,
+                           _["country_region"] = country_region,
                            _["country"] = country,
+                           _["world_region"] = world_region,
                            _["stringsAsFactors"] = false);
 }
 
@@ -184,8 +271,8 @@ CharacterVector poster_internal::get_elements(CharacterVector addresses, int ele
   unsigned int input_size = addresses.size();
   CharacterVector output(input_size);
   
-  address_parser_options_t options = get_libpostal_address_parser_default_options();
-  address_parser_options_t& opt_ref = options;
+  libpostal_address_parser_options_t options = libpostal_get_address_parser_default_options();
+  libpostal_address_parser_options_t& opt_ref = options;
   
   for(unsigned int i = 0; i < input_size; i++){
     if((i % 10000) == 0){
@@ -209,8 +296,8 @@ CharacterVector poster_internal::set_elements(CharacterVector addresses, Charact
   unsigned int input_size = addresses.size();
   CharacterVector output(input_size);
   CharacterVector holding;
-  address_parser_options_t options = get_libpostal_address_parser_default_options();
-  address_parser_options_t& opt_ref = options;
+  libpostal_address_parser_options_t options = libpostal_get_address_parser_default_options();
+  libpostal_address_parser_options_t& opt_ref = options;
   
   if(new_value.size() == 1){
     if(new_value[0] == NA_STRING){

--- a/src/poster.cpp
+++ b/src/poster.cpp
@@ -50,10 +50,13 @@ CharacterVector normalise_addr(CharacterVector addresses){
 //'
 //'@param addresses a character vector of addresses to parse.
 //'
-//'@return a data.frame of 10 columns; \code{house}, \code{house_number},
-//'\code{road}, \code{suburb}, \code{city_district}, \code{city},
+//'@return a data.frame of 20 columns; \code{house}, \code{category},
+//'\code{near}, \code{house_number}, \code{road}, \code{unit},
+//'\code{level}, \code{staircase}, \code{entrance}, \code{po_box},
+//'\code{suburb}, \code{city_district}, \code{city},
 //'\code{state_district}, \code{state}, \code{postal_code},
-//'\code{country}. Values not found in the address are represented
+//'\code{country_region}, \code{country}, \code{world_region}. 
+//'Values not found in the address are represented
 //'with \code{NA}s
 //'
 //'@examples
@@ -61,16 +64,25 @@ CharacterVector normalise_addr(CharacterVector addresses){
 //'str(parse_addr("781 Franklin Ave Crown Heights Brooklyn NYC NY 11216 USA"))
 //'}
 //'# 'data.frame':	1 obs. of  10 variables:
-//'#   $ house         : chr NA
-//'#   $ house_number  : chr "781"
-//'#   $ road          : chr "franklin ave"
-//'#   $ suburb        : chr "crown heights"
-//'#   $ city_district : chr "brooklyn"
-//'#   $ city          : chr "nyc"
-//'#   $ state_district: chr NA
-//'#   $ state         : chr "ny"
-//'#   $ postal_code   : chr NA
-//'#   $ country       : chr "usa"
+//'#   $ house          : chr NA
+//'#   $ category       : chr NA
+//'#   $ near           : chr NA
+//'#   $ house_number   : chr "781"
+//'#   $ road           : chr "franklin ave"
+//'#   $ unit           : chr NA
+//'#   $ level          : chr NA
+//'#   $ staircase      : chr NA
+//'#   $ entrance       : chr NA
+//'#   $ po_box         : chr NA
+//'#   $ suburb         : chr "crown heights"
+//'#   $ city_district  : chr "brooklyn"
+//'#   $ city           : chr "nyc"
+//'#   $ state_district : chr NA
+//'#   $ state          : chr "ny"
+//'#   $ postal_code    : chr NA
+//'#   $ country_region : chr NA
+//'#   $ country        : chr "usa"
+//'#   $ world_region   : chr NA
 //'
 //'@seealso \code{\link{normalise_addr}} for normalising addresses.
 //'


### PR DESCRIPTION
Ahoy Oliver!

We have a 1.0 for libpostal as of earlier today. Conditional Random Fields trained on 1 billion addresses, 99.45% full-parse accuracy on held-out, and a saucy new GIF.

Since I was bumping the major version anyway, I took the time to add a "libpostal_" prefix to everything in our header, as is generally good practice but I neglected to do before releasing the initial version.

This PR implements all the necessary API changes for 1.0, and adds the new parser labels, which number 20 now. I don't have an R environment set up to test it on, but think I got everything.

Also, some possibly relevant details for CRAN purposes: 1.0 removes the snappy, sparkey and mmap dependencies (compilation on Windows is maybe-sorta possible). In this version I trained the language classifier with the [FTRL-Proximal](https://research.google.com/pubs/pub41159.html) method instead of L2 regularization. The former combines the L1 and L2 penalty to encourage sparsity while keeping a . Suffice to say, the new language classifier is 1/10th the size (only 70ish MB now instead of 700), and actually a bit more accurate than its predecessor. The new address parser is larger, like 1.8GB on-disk/in-memory, but that's mostly because it trains on 10x more data, though there are some [sparsity tricks](https://www.cs.bgu.ac.il/~yoavg/publications/acl2011sparse.pdf) there as well to keep its size under control. That is to say, the size is now under 2GB (unzipped, download size is around 750MB) if that number magically changes anything.

Cheers!
./al
